### PR TITLE
Add gitignore for dist directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Created by goreleaser
+dist/


### PR DESCRIPTION
The dist directory is used to store the generated files from the goreleaser tool. This directory should be ignored by git.